### PR TITLE
kabi.pl: Fix perl comparisons

### DIFF
--- a/kabi.pl
+++ b/kabi.pl
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Getopt::Long qw(:config no_ignore_case);
+use Getopt::Long;
 use Data::Dumper;
 
 # ( { sym => regexp, mod => regexp, fail => 0/1 }, ... )


### PR DESCRIPTION
Explicitly require case sensitive comparisons since it's not given in perl.